### PR TITLE
Update the Dockerfile to reduce the amount of layers

### DIFF
--- a/Dockerfiles/ubuntu2204
+++ b/Dockerfiles/ubuntu2204
@@ -32,9 +32,8 @@ npm \
 texlive-latex-base \
 texlive-fonts-recommended \
 texlive-fonts-extra \
-texlive-latex-extra
-
-RUN gem install \
+texlive-latex-extra \
+gem install \
 asciidoctor \
 asciidoctor-bibtex \
 asciidoctor-diagram \
@@ -47,6 +46,5 @@ json \
 pygments.rb \
 rghost \
 rouge \
-ruby_dev
-
-RUN npm install -g wavedrom-cli
+ruby_dev \
+npm install -g wavedrom-cli

--- a/Dockerfiles/ubuntu2204
+++ b/Dockerfiles/ubuntu2204
@@ -33,18 +33,5 @@ texlive-latex-base \
 texlive-fonts-recommended \
 texlive-fonts-extra \
 texlive-latex-extra \
-gem install \
-asciidoctor \
-asciidoctor-bibtex \
-asciidoctor-diagram \
-asciidoctor-mathematical \
-asciidoctor-pdf \
-citeproc-ruby \
-coderay \
-csl-styles \
-json \
-pygments.rb \
-rghost \
-rouge \
-ruby_dev \
+gem install asciidoctor asciidoctor-bibtex asciidoctor-diagram asciidoctor-mathematical asciidoctor-pdf citeproc-ruby coderay csl-styles json pygments.rb rghost rouge ruby_dev \
 npm install -g wavedrom-cli


### PR DESCRIPTION
This change removes unnecessary RUN. entries from the Dockerfile in order to reduce the size of the image.

Signed-off-by: Rafael Sene <rafael@riscv.org>