### PR TITLE
Dockerfiles: Install the mermaid CLI

### DIFF
--- a/Dockerfiles/ubuntu2204
+++ b/Dockerfiles/ubuntu2204
@@ -56,5 +56,5 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     rghost \
     rouge \
     ruby_dev && \
-    npm install -g wavedrom-cli@2.6.8 bytefield-svg@1.8.0
+    npm install -g wavedrom-cli@2.6.8 bytefield-svg@1.8.0 @mermaid-js/mermaid-cli@9
 


### PR DESCRIPTION
In order to include mermaid diagrams that are both github and asciidoc compatible, we need to include the mermaid-cli package.

With that CLI, we can convert github mermaid diagrams on the fly, as shown in https://github.com/riscv-non-isa/riscv-ap-tee-io/pull/43