### PR TITLE
Add docker.io prefix to image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If if want to save time, you can easily [pull the latest image built from Docker
 > NOTE: this step assumes you already have Docker installed and configured.
 
 ```
-docker pull riscvintl/riscv-docs-base-container-image:latest
+docker pull docker.io/riscvintl/riscv-docs-base-container-image:latest
 ```
 
 ### The Branches


### PR DESCRIPTION
The default install of podman does not automatically try docker.io, and tells you to explicitly specify it, which does seem like a good idea.