### PR TITLE
Added support for EPUB builds

### DIFF
--- a/Dockerfiles/ubuntu2204
+++ b/Dockerfiles/ubuntu2204
@@ -58,6 +58,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         asciidoctor-lists \
         asciidoctor-mathematical \
         asciidoctor-pdf \
+        asciidoctor-epub3 \
         asciidoctor-kroki \
         citeproc-ruby \
         coderay \

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ To build the documentation, execute the following steps:
 # clone the upstream repository of the documentation (see The Branches)
 
 # run the build within the container from within the riscv-isa-manual directory
-docker run -it -v $(pwd)/riscv-isa-manual:/build riscvintl/riscv-docs-base-container-image:latest /bin/sh -c 'cd ./build; make'
+docker run -it -v $(pwd)/riscv-isa-manual:/build riscvintl/riscv-docs-base-container-image:latest /bin/sh -c 'EXPORT LANG=C.utf8; cd ./build; make'
 ```
 
 The build artifacts will be located within the `riscv-isa-manual` in the `build` directory, for instance:
@@ -118,6 +118,8 @@ To build the documentation, execute the following steps:
 docker run -it -v $(pwd)/riscv-isa-manual:/build riscvintl/riscv-docs-base-container-image:latest /bin/bash
 
 # within the container
+# asciidoctor-epub3's dependency SASS fails to parse SCSS files due to the encoding being set to ANSI_X3.4-1968
+export LANG=C.utf8
 cd ./build
 make
 ```


### PR DESCRIPTION
### Description

This pull requests adds `asciidoctor-epub3` as a Ruby package to be installed to support EPUB builds. It also updates the documentation to address an issue with EPUB CSS decoding: SASS (asciidoctor-epub3 dependency) relies on the environment encoding when decoding SCSS files.

### Testing

Manually built EPUB manuals.

### Known issues

None

### Related pull requests

riscv-isa-manual: [#1398](https://github.com/riscv/riscv-isa-manual/pull/1398)