### PR TITLE
README: no need to "cd build" with interactive shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ docker run -it -v $(pwd)/riscv-isa-manual:/build riscvintl/riscv-docs-base-conta
 # within the container
 # asciidoctor-epub3's dependency SASS fails to parse SCSS files due to the encoding being set to ANSI_X3.4-1968
 export LANG=C.utf8
-cd ./build
 make
 ```
 


### PR DESCRIPTION
```
$ podman run -it -v $(pwd)/riscv-isa-manual:/build riscvintl/riscv-docs-base-container-image:latest /bin/bash
root@3cf3f4092811:/build# export LANG=C.utf8
root@3cf3f4092811:/build# cd ./build
root@3cf3f4092811:/build/build# make
make: *** No targets specified and no makefile found.  Stop.
```

The interactive container starts with the current working directory as `/build'.