### PR TITLE
Update both container image dependencies

### DIFF
--- a/Dockerfiles/debian
+++ b/Dockerfiles/debian
@@ -18,6 +18,16 @@ RUN set -eux; \
         ruby-dev \
         libffi-dev \
         npm \
+        libcairo2-dev \
+        libgdk-pixbuf2.0-dev \
+        libpango1.0-dev \
+        libxml2-dev \
+        libglib2.0-dev \
+        libgif-dev \
+        libwebp-dev \
+        libzstd-dev \
+        libjpeg-dev \
+        librsvg2-dev \
     "; \
     runtimeDeps=" \
         bison \
@@ -29,16 +39,18 @@ RUN set -eux; \
         pandoc \
         graphviz \
         default-jre-headless \
-        libcairo2-dev \
-        libgdk-pixbuf2.0-dev \
-        libpango1.0-dev \
-        libxml2-dev \
-        libglib2.0-dev \
-        libgif-dev \
-        libwebp-dev \
-        libzstd-dev \
-        libjpeg-dev \
-        librsvg2-dev \
+        libcairo2 \
+        libgdk-pixbuf-2.0-0 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libpangoft2-1.0-0 \
+        libxml2 \
+        libglib2.0-0 \
+        libgif7 \
+        libwebp7 \
+        libzstd1 \
+        libjpeg62-turbo \
+        librsvg2-2 \
         ruby \
         python3-pip \
         nodejs \
@@ -48,7 +60,6 @@ RUN set -eux; \
         texlive-science \
         texlive-latex-recommended \
     "; \
-    \
     apt-get update; \
     apt-get install -y --no-install-recommends $buildDeps $runtimeDeps; \
     \
@@ -66,7 +77,6 @@ RUN set -eux; \
         asciidoctor-lists \
         asciidoctor-pdf \
         asciidoctor-epub3 \
-        asciidoctor-kroki \
         asciidoctor-diagram-ditaamini \
         asciidoctor-diagram-plantuml \
         asciidoctor-mathematical \
@@ -78,11 +88,12 @@ RUN set -eux; \
         rghost \
         rouge \
         write_xlsx; \
+    gem install --no-document 'asciidoctor-kroki:<0.10.1'; \
     \
     npm install -g wavedrom-cli@2.6.8 bytefield-svg@1.8.0; \
     npm cache clean --force; \
     \
-    # Ensure /tmp is writable by everyone
+    # Ensure /tmp is writable by everyone \
     chmod 1777 /tmp; \
     \
     apt-get purge -y --auto-remove $buildDeps; \

--- a/Dockerfiles/ubuntu2204
+++ b/Dockerfiles/ubuntu2204
@@ -1,22 +1,35 @@
 # Use Ubuntu 22.04 as the base image
 FROM ubuntu:22.04
-
 # Set maintainer label using ARG (can be set during build time)
 ARG MAINTAINER="rafael@riscv.org"
 LABEL maintainer="${MAINTAINER}"
-
+# Set XDG_CACHE_HOME to /tmp so non-root users (UID 501) can write font caches
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    XDG_CACHE_HOME=/tmp
 # Set working directory
 WORKDIR /build
-
-# Install packages in a single RUN command to reduce layers
-# Clean up the cache to reduce image size
-# Separate installations by their ecosystems for better readability and caching
-RUN export DEBIAN_FRONTEND=noninteractive && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-        bison \
+RUN set -eux; \
+    buildDeps=" \
         build-essential \
-        python3-pip \
+        python3-dev \
+        ruby-dev \
+        libffi-dev \
+        npm \
+        libcairo2-dev \
+        libgdk-pixbuf2.0-dev \
+        libpango1.0-dev \
+        libxml2-dev \
+        libglib2.0-dev \
+        libgif-dev \
+        libwebp-dev \
+        libzstd-dev \
+        libjpeg-dev \
+        librsvg2-dev \
+    "; \
+    runtimeDeps=" \
+        bison \
         cmake \
         curl \
         flex \
@@ -26,30 +39,40 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         pandoc \
         graphviz \
         default-jre \
-        libcairo2-dev \
-        libffi-dev \
-        libgdk-pixbuf2.0-dev \
-        libpango1.0-dev \
-        libxml2-dev \
-        libglib2.0-dev \
+        libcairo2 \
+        libgdk-pixbuf2.0-0 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libpangoft2-1.0-0 \
+        libxml2 \
+        libglib2.0-0 \
+        libgif7 \
+        libwebp7 \
+        libzstd1 \
+        libjpeg-turbo8 \
+        librsvg2-2 \
         make \
         pkg-config \
         ruby \
-        ruby-dev \
-        libgif-dev \
-        libwebp-dev \
-        libzstd-dev \
         ruby-full \
         gem \
-        npm \
+        python3-pip \
+        nodejs \
         texlive-latex-base \
         texlive-fonts-recommended \
         texlive-fonts-extra \
         texlive-latex-extra \
-        texlive-science && \
-    rm -rf /var/lib/apt/lists/* && \
-    pip3 install sympy pyyaml jsonschema && \
-    gem install \
+        texlive-science \
+    "; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends $buildDeps $runtimeDeps; \
+    \
+    pip3 install --no-cache-dir \
+        sympy \
+        pyyaml \
+        jsonschema; \
+    \
+    gem install --no-document \
         mathematical \
         asciidoctor \
         asciidoctor-sail \
@@ -59,7 +82,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         asciidoctor-mathematical \
         asciidoctor-pdf \
         asciidoctor-epub3 \
-        asciidoctor-kroki \
         asciidoctor-diagram-ditaamini \
         asciidoctor-diagram-plantuml \
         citeproc-ruby \
@@ -69,5 +91,17 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         pygments.rb \
         rghost \
         rouge \
-        write_xlsx && \
-    npm install -g wavedrom-cli@2.6.8 bytefield-svg@1.8.0
+        write_xlsx; \
+    gem install --no-document 'asciidoctor-kroki:<0.10.1'; \
+    \
+    npm install -g wavedrom-cli@2.6.8 bytefield-svg@1.8.0; \
+    npm cache clean --force; \
+    \
+    apt-get purge -y --auto-remove $buildDeps; \
+    rm -rf /var/lib/apt/lists/* \
+           /usr/share/doc/* \
+           /usr/share/man/* \
+           /usr/share/info/* \
+           /var/cache/apt/archives/* \
+           /tmp/* \
+           /root/.cache


### PR DESCRIPTION
This is a review based on the initial contribution from @wmat https://github.com/riscv/riscv-docs-base-container-image/pull/17.

Signed-off-by: Rafael Sene <rafael@riscv.org>
